### PR TITLE
device-type: fix primary partition number

### DIFF
--- a/jetson-nano.coffee
+++ b/jetson-nano.coffee
@@ -37,8 +37,7 @@ module.exports =
 
 	configuration:
 		config:
-			partition:
-				primary: 1
+			partition: 12
 			path: '/config.json'
 
 	initialization: commonImg.initialization


### PR DESCRIPTION
Otherwise the ImageMaker cannot get the right partition for the
configuration.

Changelog-entry: Fix primary partition number
Signed-off-by: Gergely Imreh <gergely@balena.io>