### PR TITLE
layers/meta-balena: Update meta-balena to v2.38.0

### DIFF
--- a/jetson-xavier.coffee
+++ b/jetson-xavier.coffee
@@ -11,6 +11,7 @@ module.exports =
 	name: 'Nvidia Jetson Xavier'
 	arch: 'aarch64'
 	state: 'experimental'
+	community: true
 
 	instructions: [
 		BOARD_PREPARE


### PR DESCRIPTION
Update meta-balena from 2.37.0 to 2.38.0

Changelog-entry: Update the meta-balena submodule from v2.37.0 to v2.38.0
Signed-off-by: Alexandru Costache <alexandru@balena.io>